### PR TITLE
Rename 1.0.0-rc1 to 0.1.0-rc1

### DIFF
--- a/releases/0.1.0-rc1/asset.json
+++ b/releases/0.1.0-rc1/asset.json
@@ -12,7 +12,7 @@
     },
     "schemaVersion": {
       "title": "Schema Version",
-      "default": "1.0.0-rc1",
+      "default": "0.1.0-rc1",
       "readOnly": true,
       "nskey": "schema",
       "type": "string"

--- a/releases/0.1.0-rc1/dandiset.json
+++ b/releases/0.1.0-rc1/dandiset.json
@@ -13,7 +13,7 @@
     },
     "schemaVersion": {
       "title": "Schema Version",
-      "default": "1.0.0-rc1",
+      "default": "0.1.0-rc1",
       "readOnly": true,
       "nskey": "schema",
       "type": "string"


### PR DESCRIPTION
Since that is what it pretty much was, and might be handy
to keep it around for comparison (an alternative would be to remove it).

Such explicit rename (or remove) might be desired to spot
the components which might still be using this old
schema